### PR TITLE
Check validity of FocusMode support

### DIFF
--- a/Classes/ComMfoggSquarecameraView.m
+++ b/Classes/ComMfoggSquarecameraView.m
@@ -382,7 +382,7 @@ static const NSString *AVCaptureStillImageIsCapturingStillImageContext = @"AVCap
                     d.focusMode = AVCaptureFocusModeContinuousAutoFocus;
                     [d unlockForConfiguration];
                 }
-            } else {
+            } else if ([d isFocusModeSupported:AVCaptureFocusModeContinuousAutoFocus]) {
                 NSLog(@"[INFO]: Setting the autofocus range to near!");
                
                 if ([d lockForConfiguration:nil]) {


### PR DESCRIPTION
When switching cameras (back-to-front and vice versa), we check isFocusModeSupported prior to setting the auto-focus (back only): AVCaptureFocusModeContinuousAutoFocus.