### PR TITLE
2x to 4x

### DIFF
--- a/Classes/ComMfoggSquarecameraView.m
+++ b/Classes/ComMfoggSquarecameraView.m
@@ -173,8 +173,8 @@ static const NSString *AVCaptureStillImageIsCapturingStillImageContext = @"AVCap
 
     NSLog(@"image.size : %@", NSStringFromCGSize(size));
 
-    CGFloat image_width = self.stillImage.frame.size.width*2;
-    CGFloat image_height = self.stillImage.frame.size.height*2;
+    CGFloat image_width = self.stillImage.frame.size.width*4;
+    CGFloat image_height = self.stillImage.frame.size.height*4;
 
     CGRect cropRect = CGRectMake(
       0,


### PR DESCRIPTION
Increased image output from 2x to 4x frame size. Example: iPhone X outputs an image that is 375 (device width) times 4 = 1500 pixels.